### PR TITLE
add TimeModule-based CPU summary, dropping the first event 

### DIFF
--- a/timeDiffFromReport.sh
+++ b/timeDiffFromReport.sh
@@ -14,14 +14,23 @@ if [ ! -f "${sl}" ]; then
     exit 1
 fi
 
-st=${sl}.times
 ot=${ol}.times
+st=${sl}.times
 
 grep -P "^TimeReport( [ ]*[0-9.]{1,}){6}[ ]*[^ ]*$" ${ol} |  awk '{print $8" "$2}' >  ${ot}
 grep -P "^TimeReport( [ ]*[0-9.]{1,}){6}[ ]*[^ ]*$" ${sl} |  awk '{print $8" "$2}' >  ${st}
 
+#based on per-event timing
+otm=${ol}.timesm
+stm=${sl}.timesm
+grep "^TimeModule[^$]*"  ${ol} | awk '{if(cn[$4]>0){sum[$4]+=$6;} cn[$4]++;}END{for (m in sum){print m" "sum[m]/(cn[m]-1)" "cn[m]-1}}' > ${otm}
+grep "^TimeModule[^$]*"  ${sl} | awk '{if(cn[$4]>0){sum[$4]+=$6;} cn[$4]++;}END{for (m in sum){print m" "sum[m]/(cn[m]-1)" "cn[m]-1}}' > ${stm}
+
 no=`grep [a-z] ${ot} | wc -l`
 ns=`grep [a-z] ${st} | wc -l`
+
+nom=`grep [a-z] ${otm} | wc -l`
+nsm=`grep [a-z] ${stm} | wc -l`
 
 if [ "${no}" == "0" -o "${ns}" == "0" ]; then
     echo "Couldn't parse time report using CPU and wall-clock format: trying Wall-clock only"
@@ -37,3 +46,9 @@ if [ "${no}" == "0" -o "${ns}" == "0" ]; then
 fi
 
 grep [a-zA-Z] ${ot} ${st} | tr ':' ' ' | sed -e "s?^${st}?st?g;s?^${ot}?ot?g"| awk -f ~/tools/timeDiffFromReport.awk 
+
+if [ "${nom}" != "0" -a  "${nsm}" != "0" ]; then 
+    echo 
+    echo "The same excluding the first event "
+    grep [a-zA-Z] ${otm} ${stm} | tr ':' ' ' | sed -e "s?^${stm}?st?g;s?^${otm}?ot?g"| awk -f ~/tools/timeDiffFromReport.awk 
+fi


### PR DESCRIPTION
(reduces dependence on initial loading step).
The printout becomes longer, but it's easy to separate the two.
The longer term goal is to merge the two