### PR TITLE
tau ID plots; recent wfs in the map

### DIFF
--- a/matrix_RE.txt
+++ b/matrix_RE.txt
@@ -53,6 +53,7 @@ HydjetQMinBiaswf140p0 140.0_HydjetQ_MinBias_2760GeV+HydjetQ_MinBias_2760GeV*/ste
 ZEEMMHIwf140p4 140.4_ZEEMM_13_HI+ZEEMM_13_HI*/step3.root RECO
 ZEEMMHIwf302p0 302.0_Pyquen_ZeemumuJets_pt10_2760GeV+Pyquen_ZeemumuJets_pt10_2760GeV+*/step3.root RECO
 EPOSPPb8160GeVwf281p0 281.0_EPOS_PPb_8160GeV_MinimumBias+*/step3.root RECO
+HydjetQB12in2018wf150p0 150.0_HydjetQ_B12_5020GeV_*/step3.root RECO
 #
 #  Run2 MC
 #
@@ -73,6 +74,7 @@ SingleMu13Pt1000wf1322p0 1322.0_SingleMuPt1000_UP15+*/step3.root RECO
 TTbar13wf1325p0 1325.0_TTbar_13+TTbar_13*/step3.root RECO
 TTbar13wf11325p0 11325.0_TTbar_13_unsch+TTbar_13*/step3.root RECO
 TTbar13reMINIAODwf1325p5 1325.5_TTbar_13_reminiaod*/step2.root PAT
+TTbar13nanoAODwf1325p7 1325.7_TTbar_13_94XNanoAODINPUT+*/step2.root DQM
 ZMM13TeVwf1330p0 1330.0_ZMM_13+*/step3.root RECO
 H125GG13TeVwf1332p0 1332.0_H125GGgluonfusion_13+*/step3.root RECO
 VBFH125BB13TeVwf1363p0 1363.0_VBFHToBB_M125_Pow_py8_Evt_13*/step3.root RECO
@@ -116,6 +118,7 @@ RunJetHT2016EreMINIAODwf136p7611 136.7611_RunJetHT2016E_reminiaod+*/step2.root P
 RunMET2016Ewf136p762 136.762_RunMET2016E+*/step3.root reRECO
 RunSinglePh2016Ewf136p766 136.766_RunSinglePh2016E+*/step3.root reRECO
 RunJetHT2016Hwf136p772 136.772_RunJetHT2016H+*/step3.root reRECO
+RunJetHT2016HreMINIAODwf136p7721 136.7721_RunJetHT2016H_reminiaod+*/step2.root PAT
 #
 # 2017 data
 #

--- a/validate.C
+++ b/validate.C
@@ -347,10 +347,12 @@ void metVars(TString cName = "tcMet_", TString tName = "recoMETs_") {
   met("significance",cName,tName);
 }
 
-void tau(TString var, TString cName = "hpsPFTauProducer_", TString tName = "recoPFTaus_",  bool notafunction=false){
+void tau(TString var, TString cName = "hpsPFTauProducer_", TString tName = "recoPFTaus_", 
+         bool log10Var = false, bool trycatch = false, bool notafunction = false){
   TString v=notafunction ? tName+cName+"_"+recoS+".obj."+var:
     tName+cName+"_"+recoS+".obj."+var+"()";
-  plotvar(v);
+  if (log10Var) v = "log10(" + v + ")";
+  plotvar(v, "", trycatch);
 }
 
 void tauVars(TString cName = "hpsPFTauProducer_", TString tName = "recoPFTaus_"){
@@ -360,6 +362,41 @@ void tauVars(TString cName = "hpsPFTauProducer_", TString tName = "recoPFTaus_")
   tau("eta",cName,tName);
   tau("phi",cName,tName);
   if (tName!="patTaus_") tau("emFraction",cName,tName);//crashes now for patTaus
+
+  if (tName == "patTaus_"){
+    tau("dxy", cName, tName);
+    tau("dxy_error", cName, tName);
+
+    tau("ip3d", cName, tName);
+    tau("ip3d_error", cName, tName);
+    tau("ecalEnergy", cName, tName);
+    tau("hcalEnergy", cName, tName);
+    tau("leadingTrackNormChi2", cName, tName);
+    tau("ecalEnergyLeadChargedHadrCand", cName, tName);
+    tau("hcalEnergyLeadChargedHadrCand", cName, tName);
+    tau("etaAtEcalEntrance", cName, tName);
+    tau("etaAtEcalEntranceLeadChargedCand", cName, tName);
+    tau("ptLeadChargedCand", cName, tName);
+    tau("emFraction_MVA", cName, tName);
+
+    tau("userFloats_@.size", cName,tName);
+    for (int i = 0; i< 32; ++i){
+      plotvar(tName+cName+"_"+recoS+Form(".obj[].userFloats_[%d]",i), "", true);
+    }
+    tau("userInts_@.size", cName,tName);
+    for (int i = 0; i< 32; ++i){
+      plotvar(tName+cName+"_"+recoS+Form(".obj[].userInts_[%d]",i), "", true);
+    }
+    tau("userCands_@.size", cName,tName);
+    tau("isolations_@.size", cName,tName);
+    for (int i = 0; i< 12; ++i){
+      plotvar(tName+cName+"_"+recoS+Form(".obj[].isolations_[%d]",i), "", true);
+    }
+    tau("tauIDs_@.size", cName,tName);
+    for (int i = 0; i< 82; ++i){
+      plotvar(tName+cName+"_"+recoS+Form(".obj[].tauIDs_[%d].second",i), "", true);
+    }
+  }
 }
 
 void photon(TString var, TString cName = "photons_", TString tName = "recoPhotons_", bool notafunction=false){
@@ -2121,40 +2158,8 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       tauVars("hpsPFTauProducer_");
       // miniaod
       tauVars("slimmedTaus_","patTaus_");
-      //pat::Tau specifics
-      plotvar("patTaus_slimmedTaus__"+recoS+".obj.dxy()");
-      plotvar("patTaus_slimmedTaus__"+recoS+".obj.dxy_error()");
-
-      plotvar("patTaus_slimmedTaus__"+recoS+".obj.ip3d()");
-      plotvar("patTaus_slimmedTaus__"+recoS+".obj.ip3d_error()");
-      plotvar("patTaus_slimmedTaus__"+recoS+".obj.ecalEnergy()");
-      plotvar("patTaus_slimmedTaus__"+recoS+".obj.hcalEnergy()");
-      plotvar("patTaus_slimmedTaus__"+recoS+".obj.leadingTrackNormChi2()");
-      plotvar("patTaus_slimmedTaus__"+recoS+".obj.ecalEnergyLeadChargedHadrCand()");
-      plotvar("patTaus_slimmedTaus__"+recoS+".obj.hcalEnergyLeadChargedHadrCand()");
-      plotvar("patTaus_slimmedTaus__"+recoS+".obj.etaAtEcalEntrance()");
-      plotvar("patTaus_slimmedTaus__"+recoS+".obj.etaAtEcalEntranceLeadChargedCand()");
-      plotvar("patTaus_slimmedTaus__"+recoS+".obj.ptLeadChargedCand()");
-      plotvar("patTaus_slimmedTaus__"+recoS+".obj.emFraction_MVA()");
-
       // boosted tau reco
-      // miniaod
       tauVars("slimmedTausBoosted_","patTaus_");
-      //pat::Tau specifics
-      plotvar("patTaus_slimmedTausBoosted__"+recoS+".obj.dxy()");
-      plotvar("patTaus_slimmedTausBoosted__"+recoS+".obj.dxy_error()");
-
-      plotvar("patTaus_slimmedTausBoosted__"+recoS+".obj.ip3d()");
-      plotvar("patTaus_slimmedTausBoosted__"+recoS+".obj.ip3d_error()");
-      plotvar("patTaus_slimmedTausBoosted__"+recoS+".obj.ecalEnergy()");
-      plotvar("patTaus_slimmedTausBoosted__"+recoS+".obj.hcalEnergy()");
-      plotvar("patTaus_slimmedTausBoosted__"+recoS+".obj.leadingTrackNormChi2()");
-      plotvar("patTaus_slimmedTausBoosted__"+recoS+".obj.ecalEnergyLeadChargedHadrCand()");
-      plotvar("patTaus_slimmedTausBoosted__"+recoS+".obj.hcalEnergyLeadChargedHadrCand()");
-      plotvar("patTaus_slimmedTausBoosted__"+recoS+".obj.etaAtEcalEntrance()");
-      plotvar("patTaus_slimmedTausBoosted__"+recoS+".obj.etaAtEcalEntranceLeadChargedCand()");
-      plotvar("patTaus_slimmedTausBoosted__"+recoS+".obj.ptLeadChargedCand()");
-      plotvar("patTaus_slimmedTausBoosted__"+recoS+".obj.emFraction_MVA()");
 
       //upstream discriminators
       plotvar("recoPFTauDiscriminator_hpsPFTauDiscriminationByIsolationMVArun2v1PWdR03oldDMwLTraw__"+recoS+".obj.data_");


### PR DESCRIPTION
- refactor tau plot parts for patTaus
- add plots for tauIDs and other "user" variables

- add HI2018 MC 150.0 , nanoAOD MC 1325.7, and 2016H reminiAOD 136.7721 wfs  to the map (this will also silence the warning message showing up in every PR about a missing map for the nanoAOD wf. ... I left it there for some time hoping for a faster implementation of some basic nanoAOD monitoring in validate.C)