### PR TITLE
map updates; validate.C recen muon variables, PF debug plots, more strict configuration

### DIFF
--- a/matrix_RE.txt
+++ b/matrix_RE.txt
@@ -51,45 +51,45 @@ RunHI2011wf140p53 140.53_RunHI2011+RunHI2011+*/step2.root reRECO
 HydjetQwf40p0 40.0_HydjetQ_MinBias_2760GeV+HydjetQ_MinBias_2760GeV*/step3.root RECO
 HydjetQMinBiaswf140p0 140.0_HydjetQ_MinBias_2760GeV+HydjetQ_MinBias_2760GeV*/step3.root RECO
 ZEEMMHIwf140p4 140.4_ZEEMM_13_HI+ZEEMM_13_HI*/step3.root RECO
-ZEEMMHIwf302p0 302.0_Pyquen_ZeemumuJets_pt10_2760GeV+Pyquen_ZeemumuJets_pt10_2760GeV+*/step3.root RECO
-EPOSPPb8160GeVwf281p0 281.0_EPOS_PPb_8160GeV_MinimumBias+*/step3.root RECO
+ZEEMMHIwf302p0 302.0_Pyquen_ZeemumuJets_pt10_2760GeV+Pyquen_ZeemumuJets_pt10_2760GeV*/step3.root RECO
+EPOSPPb8160GeVwf281p0 281.0_EPOS_PPb_8160GeV_MinimumBias*/step3.root RECO
 HydjetQB12in2018wf150p0 150.0_HydjetQ_B12_5020GeV_*/step3.root RECO
 #
 #  Run2 MC
 #
-QCD13TeVPt3Ts3T5wf1313p0 1313.0_QCD_Pt_3000_3500_13+*/step3.root RECO
+QCD13TeVPt3Ts3T5wf1313p0 1313.0_QCD_Pt_3000_3500_13*/step3.root RECO
 ZpEE2250wf1344p0 1344.0_ZpEE_2250_13TeV+ZpEE_2250_13TeV*/step3.root RECO
 ZpTT1500wf1345p0 1345.0_ZpTT_1500_13TeV*/step3.root RECO
 CosmicsUP15wf1307p0 1307.0_Cosmics*/step3.root RECO
 BeamHalo13wf1308p0 1308.0_BeamHalo_13+BeamHalo_13*/step3.root RECO
 BuJpsiK13TeVwf1340p0 1340.0_BuJpsiK_13+BuJpsiK_13*/step3.root RECO
-QCD13TeVFlatPt15s3000wf1338p0 1338.0_QCD_FlatPt_15_3000HS_13+*/step3.root RECO
-SingleElectron13Pt1000wf1316p0 1316.0_SingleElectronPt1000_UP15+*/step3.root RECO
-SingleElectron13Pt35wf1317p0 1317.0_SingleElectronPt35_UP15+*/step3.root RECO
-SingleGamma13Pt10wf1318p0 1318.0_SingleGammaPt10_UP15+*/step3.root RECO
-SingleGamma13Pt35wf1319p0 1319.0_SingleGammaPt35_UP15+*/step3.root RECO
-SingleMu13Pt10wf1320p0 1320.0_SingleMuPt10_UP15+*/step3.root RECO
+QCD13TeVFlatPt15s3000wf1338p0 1338.0_QCD_FlatPt_15_3000HS_13*/step3.root RECO
+SingleElectron13Pt1000wf1316p0 1316.0_SingleElectronPt1000_UP15*/step3.root RECO
+SingleElectron13Pt35wf1317p0 1317.0_SingleElectronPt35_UP15*/step3.root RECO
+SingleGamma13Pt10wf1318p0 1318.0_SingleGammaPt10_UP15*/step3.root RECO
+SingleGamma13Pt35wf1319p0 1319.0_SingleGammaPt35_UP15*/step3.root RECO
+SingleMu13Pt10wf1320p0 1320.0_SingleMuPt10_UP15*/step3.root RECO
 SingleMu13Pt100wf1321p0 1321.0_SingleMuPt100_UP15+SingleMuPt100_UP15*/step3.root RECO
-SingleMu13Pt1000wf1322p0 1322.0_SingleMuPt1000_UP15+*/step3.root RECO
+SingleMu13Pt1000wf1322p0 1322.0_SingleMuPt1000_UP15*/step3.root RECO
 TTbar13wf1325p0 1325.0_TTbar_13+TTbar_13*/step3.root RECO
 TTbar13wf11325p0 11325.0_TTbar_13_unsch+TTbar_13*/step3.root RECO
 TTbar13reMINIAODwf1325p5 1325.5_TTbar_13_reminiaod*/step2.root PAT
 ZEE13reMINIAODwf1325p5 1325.5_ProdZEE_13_reminiaod*/step2.root PAT
 TTbar13reMINIAODwf1325p51 1325.51_TTbar_13_94Xreminiaod*/step2.root PAT
-TTbar13nanoAODwf1325p7 1325.7_TTbar_13_94XNanoAOD*/step2.root DQM
-ZMM13TeVwf1330p0 1330.0_ZMM_13+*/step3.root RECO
-H125GG13TeVwf1332p0 1332.0_H125GGgluonfusion_13+*/step3.root RECO
+TTbar13nanoAODwf1325p7 1325.7_TTbar_13_94X*NanoAOD*/step2.root DQM
+ZMM13TeVwf1330p0 1330.0_ZMM_13*/step3.root RECO
+H125GG13TeVwf1332p0 1332.0_H125GGgluonfusion_13*/step3.root RECO
 VBFH125BB13TeVwf1363p0 1363.0_VBFHToBB_M125_Pow_py8_Evt_13*/step3.root RECO
 BsToJpsiPhi13TeVwf1366p0 1366.0_BsToJpsiPhi_13+BsToJpsiPhi_13*/step3.root RECO
-SingleMu13Pt1wf1306p0 1306.0_SingleMuPt1_UP15+*/step3.root RECO
-ZEEFS13wf135p4 135.4_ZEE_13+ZEEFS_13+*/step1.root HLT
+SingleMu13Pt1wf1306p0 1306.0_SingleMuPt1_UP15*/step3.root RECO
+ZEEFS13wf135p4 135.4_ZEE_13+ZEEFS_13*/step1.root HLT
 ZEEPUwf25200p0 25200.0_ZEE_13+ZEE_13*/step3.root RECO
 TTbarPUwf25202p0 25202.0_TTbar_13+TTbar_13*/step3.root RECO
 TTbarPUwf50202p0 50202.0_TTbar_13+TTbar_13*/step3.root RECO
 H125GG13TeVPUwf25203p0 25203.0_H125GGgluonfusion_13+H125GGgluonfusion_13*/step3.root RECO
 ZMMPUwf25206p0 25206.0_ZMM_13+ZMM_13*/step3.root RECO
 QCD13TeVFlatPt15s3000PUwf25209p0 25209.0_QCD_FlatPt_15_3000HS_13+QCD_FlatPt_15_3000HS_13*/step3.root RECO
-VBFH125BB13TeVPUwf25213p0 25213.0_VBFHToBB_M125_Pow_py8_Evt_13+*/step3.root RECO
+VBFH125BB13TeVPUwf25213p0 25213.0_VBFHToBB_M125_Pow_py8_Evt_13*/step3.root RECO
 ProdZEE13TeVPUpmxwf250200p1 250200.1_ProdZEE_13*/step3.root RECO
 TTbar13TeVPUpmxwf250202p0 250202.0_TTbar_13*/step3.root RECO
 ProdTTbar13TeVPUpmxwf250202p1 250202.1_ProdTTbar_13*/step3.root RECO
@@ -139,8 +139,8 @@ RunMET2017F136p832 136.832_RunMET2017F+*/step3.root reRECO
 #
 # 2017 workflows follow
 #
-Cosmics2017wf7p2 7.2_Cosmics_UP17+*/step3.root RECO
-CosmicsSPLoose2017wf7p3 7.3_CosmicsSPLoose_UP17+*/step3.root RECO
+Cosmics2017wf7p2 7.2_Cosmics_UP17*/step3.root RECO
+CosmicsSPLoose2017wf7p3 7.3_CosmicsSPLoose_UP17*/step3.root RECO
 SingleElectronPt35in2017wf10002p0 10002.0_SingleElectronPt35+SingleElectronPt35_pythia8_2017*/step3.root RECO
 SingleElectronPt1000in2017wf10003p0 10003.0_SingleElectronPt1000+SingleElectronPt1000_pythia8_2017*/step3.root RECO
 SingleGammaPt10in2017wf10004p0 10004.0_SingleGammaPt10+SingleGammaPt10_pythia8_2017*/step3.root RECO
@@ -528,14 +528,14 @@ TTbar14TeV2023D18PUwf23434p0 23434.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D1
 #
 #   D17
 #
-SingleElectronPt35in2023D17wf20002p0 20002.0_SingleElectronPt35+SingleElectronPt35_pythia8_2023D17_GenSimHLBeamSpotFull+*/step3.root RECO
-SingleElectronPt1000in2023D17wf20003p0 20003.0_SingleElectronPt1000+SingleElectronPt1000_pythia8_2023D17_GenSimHLBeamSpotFull+*/step3.root RECO
-SingleMuPt10in2023D17wf20007p0 20007.0_SingleMuPt10+SingleMuPt10_pythia8_2023D17_GenSimHLBeamSpotFull+*/step3.root RECO
-SingleMuPt1000in2023D17wf20009p0 20009.0_SingleMuPt1000+SingleMuPt1000_pythia8_2023D17_GenSimHLBeamSpotFull+*/step3.root RECO
-TenMuExtendedE2023D17wf20011p0 20011.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D17_GenSimHLBeamSpotFull+*/step3.root RECO
-TTbar14TeV2023D17wf20034p0 20034.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D17_GenSimHLBeamSpotFull14+*/step3.root RECO
-ZEE14TeV2023D17wf20046p0 20046.0_ZEE_14+ZEE_14TeV_TuneCUETP8M1_2023D17_GenSimHLBeamSpotFull14+*/step3.root RECO
-QCD600to800in14TeV2023D17wf20053p0 20053.0_QCD_Pt_600_800_14+QCD_Pt_600_800_14TeV_TuneCUETP8M1_2023D17_GenSimHLBeamSpotFull14+*/step3.root RECO
+SingleElectronPt35in2023D17wf20002p0 20002.0_SingleElectronPt35+SingleElectronPt35_pythia8_2023D17_GenSimHLBeamSpotFull*/step3.root RECO
+SingleElectronPt1000in2023D17wf20003p0 20003.0_SingleElectronPt1000+SingleElectronPt1000_pythia8_2023D17_GenSimHLBeamSpotFull*/step3.root RECO
+SingleMuPt10in2023D17wf20007p0 20007.0_SingleMuPt10+SingleMuPt10_pythia8_2023D17_GenSimHLBeamSpotFull*/step3.root RECO
+SingleMuPt1000in2023D17wf20009p0 20009.0_SingleMuPt1000+SingleMuPt1000_pythia8_2023D17_GenSimHLBeamSpotFull*/step3.root RECO
+TenMuExtendedE2023D17wf20011p0 20011.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D17_GenSimHLBeamSpotFull*/step3.root RECO
+TTbar14TeV2023D17wf20034p0 20034.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D17_GenSimHLBeamSpotFull14*/step3.root RECO
+ZEE14TeV2023D17wf20046p0 20046.0_ZEE_14+ZEE_14TeV_TuneCUETP8M1_2023D17_GenSimHLBeamSpotFull14*/step3.root RECO
+QCD600to800in14TeV2023D17wf20053p0 20053.0_QCD_Pt_600_800_14+QCD_Pt_600_800_14TeV_TuneCUETP8M1_2023D17_GenSimHLBeamSpotFull14*/step3.root RECO
 #
 #   D17Timing
 #
@@ -543,10 +543,10 @@ TTbar14TeV2023D17Timingwf20034p2 20034.2_TTbar_14TeV_Timing+TTbar_14TeV_TuneCUET
 #
 #   D17PU
 #
-TenMuExtendedE2023D17PUwf20211p0 20211.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D17PU_GenSimHLBeamSpotFull+*/step3.root RECO
-TTbar14TeV2023D17PUwf20234p0 20234.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D17PU_GenSimHLBeamSpotFull14+*/step3.root RECO
-ZEE14TeV2023D17PUwf20246p0 20246.0_ZEE_14+ZEE_14TeV_TuneCUETP8M1_2023D17PU_GenSimHLBeamSpotFull14+*/step3.root RECO
-QCD600to800in14TeV2023D17PUwf20253p0 20253.0_QCD_Pt_600_800_14+QCD_Pt_600_800_14TeV_TuneCUETP8M1_2023D17PU_GenSimHLBeamSpotFull14+*/step3.root RECO
+TenMuExtendedE2023D17PUwf20211p0 20211.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D17PU_GenSimHLBeamSpotFull*/step3.root RECO
+TTbar14TeV2023D17PUwf20234p0 20234.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D17PU_GenSimHLBeamSpotFull14*/step3.root RECO
+ZEE14TeV2023D17PUwf20246p0 20246.0_ZEE_14+ZEE_14TeV_TuneCUETP8M1_2023D17PU_GenSimHLBeamSpotFull14*/step3.root RECO
+QCD600to800in14TeV2023D17PUwf20253p0 20253.0_QCD_Pt_600_800_14+QCD_Pt_600_800_14TeV_TuneCUETP8M1_2023D17PU_GenSimHLBeamSpotFull14*/step3.root RECO
 #
 #   D17PUTiming
 #
@@ -554,14 +554,14 @@ TTbar14TeV2023D17PUTimingwf20234p2 20234.2_TTbar_14TeV_Timing+TTbar_14TeV_TuneCU
 #
 #   D19
 #
-SingleElectronPt35in2023D19wf20402p0 20402.0_SingleElectronPt35+SingleElectronPt35_pythia8_2023D19_GenSimHLBeamSpotFull+*/step3.root RECO
-SingleElectronPt1000in2023D19wf20403p0 20403.0_SingleElectronPt1000+SingleElectronPt1000_pythia8_2023D19_GenSimHLBeamSpotFull+*/step3.root RECO
-SingleMuPt10in2023D19wf20407p0 20407.0_SingleMuPt10+SingleMuPt10_pythia8_2023D19_GenSimHLBeamSpotFull+*/step3.root RECO
-SingleMuPt1000in2023D19wf20409p0 20409.0_SingleMuPt1000+SingleMuPt1000_pythia8_2023D19_GenSimHLBeamSpotFull+*/step3.root RECO
-TenMuExtendedE2023D19wf20411p0 20411.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D19_GenSimHLBeamSpotFull+*/step3.root RECO
-TTbar14TeV2023D19wf20434p0 20434.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D19_GenSimHLBeamSpotFull14+*/step3.root RECO
-ZEE14TeV2023D19wf20446p0 20446.0_ZEE_14+ZEE_14TeV_TuneCUETP8M1_2023D19_GenSimHLBeamSpotFull14+*/step3.root RECO
-QCD600to800in14TeV2023D19wf20453p0 20453.0_QCD_Pt_600_800_14+QCD_Pt_600_800_14TeV_TuneCUETP8M1_2023D19_GenSimHLBeamSpotFull14+*/step3.root RECO
+SingleElectronPt35in2023D19wf20402p0 20402.0_SingleElectronPt35+SingleElectronPt35_pythia8_2023D19_GenSimHLBeamSpotFull*/step3.root RECO
+SingleElectronPt1000in2023D19wf20403p0 20403.0_SingleElectronPt1000+SingleElectronPt1000_pythia8_2023D19_GenSimHLBeamSpotFull*/step3.root RECO
+SingleMuPt10in2023D19wf20407p0 20407.0_SingleMuPt10+SingleMuPt10_pythia8_2023D19_GenSimHLBeamSpotFull*/step3.root RECO
+SingleMuPt1000in2023D19wf20409p0 20409.0_SingleMuPt1000+SingleMuPt1000_pythia8_2023D19_GenSimHLBeamSpotFull*/step3.root RECO
+TenMuExtendedE2023D19wf20411p0 20411.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D19_GenSimHLBeamSpotFull*/step3.root RECO
+TTbar14TeV2023D19wf20434p0 20434.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D19_GenSimHLBeamSpotFull14*/step3.root RECO
+ZEE14TeV2023D19wf20446p0 20446.0_ZEE_14+ZEE_14TeV_TuneCUETP8M1_2023D19_GenSimHLBeamSpotFull14*/step3.root RECO
+QCD600to800in14TeV2023D19wf20453p0 20453.0_QCD_Pt_600_800_14+QCD_Pt_600_800_14TeV_TuneCUETP8M1_2023D19_GenSimHLBeamSpotFull14*/step3.root RECO
 #
 #   D19Timing
 #
@@ -569,19 +569,19 @@ TTbar14TeV2023D19Timingwf20434p2 20434.2_TTbar_14TeV_Timing+TTbar_14TeV_TuneCUET
 #
 #   D19PU
 #
-TenMuExtendedE2023D19PUwf20611p0 20611.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D19PU_GenSimHLBeamSpotFull+*/step3.root RECO
-TTbar14TeV2023D19PUwf20634p0 20634.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D19PU_GenSimHLBeamSpotFull14+*/step3.root RECO
-ZEE14TeV2023D19PUwf20646p0 20646.0_ZEE_14+ZEE_14TeV_TuneCUETP8M1_2023D19PU_GenSimHLBeamSpotFull14+*/step3.root RECO
-QCD600to800in14TeV2023D19PUwf20653p0 20653.0_QCD_Pt_600_800_14+QCD_Pt_600_800_14TeV_TuneCUETP8M1_2023D19PU_GenSimHLBeamSpotFull14+*/step3.root RECO
+TenMuExtendedE2023D19PUwf20611p0 20611.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D19PU_GenSimHLBeamSpotFull*/step3.root RECO
+TTbar14TeV2023D19PUwf20634p0 20634.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D19PU_GenSimHLBeamSpotFull14*/step3.root RECO
+ZEE14TeV2023D19PUwf20646p0 20646.0_ZEE_14+ZEE_14TeV_TuneCUETP8M1_2023D19PU_GenSimHLBeamSpotFull14*/step3.root RECO
+QCD600to800in14TeV2023D19PUwf20653p0 20653.0_QCD_Pt_600_800_14+QCD_Pt_600_800_14TeV_TuneCUETP8M1_2023D19PU_GenSimHLBeamSpotFull14*/step3.root RECO
 #
 #   D19PUTiming
 #
-TTbar14TeV2023D19PUTimingwf20634p2 20634.2_TTbar_14TeV_Timing+TTbar_14TeV_TuneCUETP8M1_2023D19PU_GenSimHLBeamSpotFull14_Timing+*/step3.root RECO
+TTbar14TeV2023D19PUTimingwf20634p2 20634.2_TTbar_14TeV_Timing+TTbar_14TeV_TuneCUETP8M1_2023D19PU_GenSimHLBeamSpotFull14_Timing*/step3.root RECO
 #
 #   D20
 #
-TenMuExtendedE2023D20wf20811p0 20811.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D20_GenSimHLBeamSpotFull+*/step3.root RECO
-TTbar14TeV2023D20wf20834p0 20834.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D20_GenSimHLBeamSpotFull14+*/step3.root RECO
+TenMuExtendedE2023D20wf20811p0 20811.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D20_GenSimHLBeamSpotFull*/step3.root RECO
+TTbar14TeV2023D20wf20834p0 20834.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D20_GenSimHLBeamSpotFull14*/step3.root RECO
 #
 #   D21
 #

--- a/matrix_RE.txt
+++ b/matrix_RE.txt
@@ -197,6 +197,7 @@ SingleGammaPt10in2018wf10804p0 10804.0_SingleGammaPt10+SingleGammaPt10_pythia8_2
 SingleGammaPt35in2018wf10805p0 10805.0_SingleGammaPt35+SingleGammaPt35_pythia8_2018*_GenSimFull*+*/step3.root RECO
 SingleMuPt10in2018wf10807p0 10807.0_SingleMuPt10+SingleMuPt10_pythia8_2018*_GenSimFull*+*/step3.root RECO
 SingleMuPt1000in2018wf10809p0 10809.0_SingleMuPt1000+SingleMuPt1000_pythia8_2018*_GenSimFull*+*/step3.root RECO
+TenMuExtendedE2018wf10811p0 10811.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2018*_GenSimFull*+*/step3.root RECO
 TenMuE2018wf10821p0 10821.0_TenMuE_0_200+TenMuE_0_200_pythia8_2018*_GenSimFull*+*/step3.root RECO
 MinBias13TeV2018wf10823p0 10823.0_MinBias_13+MinBias_13TeV_pythia8_TuneCUETP8M1_2018*_GenSimFull*+*/step3.root RECO
 TTbar13TeV2018wf10824p0 10824.0_TTbar_13+TTbar_13TeV_TuneCUETP8M1_2018*_GenSimFull*+*/step3.root RECO

--- a/validate.C
+++ b/validate.C
@@ -64,7 +64,11 @@ double plotvar(TString v,TString cut="", bool tryCatch = false){
   vn.ReplaceAll("@","AT");
   vn.ReplaceAll("[","_");
   vn.ReplaceAll("]","_");
-  
+  vn.ReplaceAll(">","GT");
+  vn.ReplaceAll("<","LT");
+  vn.ReplaceAll("$","");
+  vn.ReplaceAll("&","N");
+
   if (limit!="")
     selection *= limit;
   
@@ -1013,7 +1017,7 @@ void generalTrack(TString var){
 }
 
 
-void pf(TString var,int type=-1, TString cName = "particleFlow_"){ 
+void pf(TString var,int type=-1, TString cName = "particleFlow_", bool hadDebug = false){ 
   TString v="recoPFCandidates_"+cName+"_"+recoS+".obj."+var+"()";
   if (var == "p" || var == "pt"){
     v = "log10("+v+")";
@@ -1032,6 +1036,7 @@ void pf(TString var,int type=-1, TString cName = "particleFlow_"){
     sel+=type;
     //std::cout<<"selecting "<<sel<<std::endl;
     plotvar(v,sel);
+
   }
 }
 
@@ -2397,12 +2402,37 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       gsfTrackVars("reducedEgamma_reducedGsfTracks");
     }
 
+    if (step.Contains("pfdebug")){
+      //for tests of PF hadron corrs
+      TString var = "pt";
+      TString pfName="recoPFCandidates_particleFlow__"+recoS+".obj";
+      TString pfAl="particleFlow";
+      refEvents->SetAlias(pfAl, pfName);
+      Events->SetAlias(pfAl, pfName);
+      TString v=pfAl+"."+var+"()";
+      for (int i = 1; i< 6; ++i){
+        TString sel=pfAl+".particleId()=="; sel+=i;
+        TString sel2 = sel+"&&abs("+pfAl+".eta())<1.5";
+        plotvar("log10("+v+")",sel2);
+        sel2 = sel+"&&abs("+pfAl+".eta())>1.5&&abs("+pfAl+".eta())<2.5";
+        plotvar("log10("+v+")",sel2);
+        sel2 = sel+"&&abs("+pfAl+".eta())>2.5";
+        plotvar("log10("+v+")",sel2);
+        sel2 = sel+"&&abs("+pfAl+".eta())<1.5";
+        plotvar("log10(Sum$("+v+"*("+sel2+")))");
+        sel2 = sel+"&&abs("+pfAl+".eta())>1.5&&abs("+pfAl+".eta())<2.5";
+        plotvar("log10(Sum$("+v+"*("+sel2+")))");
+        sel2 = sel+"&&abs("+pfAl+".eta())>2.5";
+        plotvar("log10(Sum$("+v+"*("+sel2+")))");
+      }
+    }//step.Contains("pfdebug")
+
     if (step.Contains("all") || step.Contains("pflow")){
       ///particle flow objects
 
-      allpf();
+      allpf(-1, "particleFlow_");
       //for each sub category ...
-      for (int t=1;t!=8;t++)	allpf(t);
+      for (int t=1;t!=8;t++)	allpf(t, "particleFlow_");
 
       allpf(-1, "particleFlowTmp_");
       //for each sub category ...

--- a/validate.C
+++ b/validate.C
@@ -41,6 +41,23 @@ void print( TString step){
 
 }
 
+// Underscores have a special meaning: most common use for steps with an underscore
+// is for the last pattern to mean the used workflow.
+// The workflow names so far had no underscores, but some can match the selection pattern.
+// To disambiguate:
+// append an underscore during pattern matching to steps with underscores present
+bool stepContainsNU(const TString& s, TString v){
+  if (!v.Contains("_")){
+    if (s.Contains("_")){
+      return s.Contains(v+"_");
+    } else {
+      return s.Contains(v);
+    }
+  } else {
+    return s.Contains(v);
+  }
+}
+
 double plotvar(TString v,TString cut="", bool tryCatch = false){
 
   std::cout<<"plotting variable: "<<v<<std::endl;
@@ -1182,9 +1199,9 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
 
   std::cout<<"Start making plots for Events with "<<Nnew<<" events and refEvents with "<<Nref<<" events ==> check  "<<Nmax<<std::endl;
 
-  if (!step.Contains("hlt")){
+  if (!stepContainsNU(step, "hlt")){
 
-    if ((step.Contains("all") || step.Contains("error"))){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "error"))){
       tbr="edmErrorSummaryEntrys_logErrorHarvester__";
       plotvar(tbr+recoS+".obj@.size()");
       plotvar(tbr+recoS+".obj.count");
@@ -1192,7 +1209,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar(tbr+recoS+".obj.category.size()");
     }
 
-    if (step.Contains("all")){
+    if (stepContainsNU(step, "all")){
       plotvar("HBHEDataFramesSorted_simHcalUnsuppressedDigis__"+recoS+".obj.obj@.size()");
       plotvar("HODataFramesSorted_simHcalUnsuppressedDigis__"+recoS+".obj.obj@.size()");
       plotvar("HFDataFramesSorted_simHcalUnsuppressedDigis__"+recoS+".obj.obj@.size()");
@@ -1214,7 +1231,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar("QIE10DataFrameHcalDataFrameContainer_hcalDigis_ZDC_"+recoS+".obj.m_ids@.size()");
     }
 
-    if (step.Contains("all") || step.Contains("ctpps")){
+    if (stepContainsNU(step, "all") || stepContainsNU(step, "ctpps")){
       //CTPPS
       tbr="TotemFEDInfos_totemRPRawToDigi_RP_";
       plotvar(tbr+recoS+".obj@.size()");
@@ -1377,7 +1394,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar(tbr+recoS+".obj.getTimeUnc()");      
     }
 
-    if ((step.Contains("all") || step.Contains("halo"))){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "halo"))){
       tbr="recoBeamHaloSummary_BeamHaloSummary__";
       plotvar(tbr+recoS+".obj.HcalLooseHaloId()");
       plotvar(tbr+recoS+".obj.HcalTightHaloId()");
@@ -1427,7 +1444,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar(tbr+recoS+".obj.getProblematicStrips().energyRatio");
       plotvar(tbr+recoS+".obj.getProblematicStrips().emEt");
     }
-    if ((step.Contains("all") || step.Contains("hcal")) && !step.Contains("cosmic") ){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "hcal")) && !stepContainsNU(step, "cosmic") ){
       //hcal rechit plots
       plotvar("HBHERecHitsSorted_hbheprereco__"+recoS+".obj.obj@.size()");
       plotvar("HBHERecHitsSorted_hbheprereco__"+recoS+".obj.obj.energy()");
@@ -1463,7 +1480,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar("HBHERecHitsSorted_hbhereco__"+recoS+".obj.obj.time()", "HBHERecHitsSorted_hbhereco__"+recoS+".obj.obj.id().subdet()!=1");
       plotvar("log10(HBHERecHitsSorted_hbhereco__"+recoS+".obj.obj.chi2())", "HBHERecHitsSorted_hbhereco__"+recoS+".obj.obj.id().subdet()!=1");
 
-      if (step.Contains("hcalHEP17")){
+      if (stepContainsNU(step, "HEP17")){
 	plotvar("HBHERecHitsSorted_hbhereco__"+recoS+".obj.obj.energy()", "HBHERecHitsSorted_hbhereco__"+recoS+".obj.obj.id().subdet()!=1&&HBHERecHitsSorted_hbhereco__"+recoS+".obj.obj.id().iphi()>=63&&HBHERecHitsSorted_hbhereco__"+recoS+".obj.obj.id().iphi()<=66");
 	plotvar("log10(HBHERecHitsSorted_hbhereco__"+recoS+".obj.obj.energy())", "HBHERecHitsSorted_hbhereco__"+recoS+".obj.obj.id().subdet()!=1&&HBHERecHitsSorted_hbhereco__"+recoS+".obj.obj.id().iphi()>=63&&HBHERecHitsSorted_hbhereco__"+recoS+".obj.obj.id().iphi()<=66");
 	plotvar("log10(HBHERecHitsSorted_hbhereco__"+recoS+".obj.obj.energy())", "HBHERecHitsSorted_hbhereco__"+recoS+".obj.obj.energy()>0.001&&HBHERecHitsSorted_hbhereco__"+recoS+".obj.obj.id().subdet()!=1&&HBHERecHitsSorted_hbhereco__"+recoS+".obj.obj.id().iphi()>=63&&HBHERecHitsSorted_hbhereco__"+recoS+".obj.obj.id().iphi()<=66");
@@ -1597,7 +1614,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar("HGCRecHitsSorted_HGCalRecHit_HGCHEBRecHits_"+recoS+".obj.obj.outOfTimeChi2()");
     }
 
-    if ((step.Contains("all") || step.Contains("preshower")) && !step.Contains("cosmic") ){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "preshower")) && !stepContainsNU(step, "cosmic") ){
       //pre-shower rechit plots
       plotvar("EcalRecHitsSorted_ecalPreshowerRecHit_EcalRecHitsES_"+recoS+".obj.obj@.size()");
       plotvar("EcalRecHitsSorted_ecalPreshowerRecHit_EcalRecHitsES_"+recoS+".obj.obj.energy()");
@@ -1635,7 +1652,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
 
     }
 
-    if ((step.Contains("all") || step.Contains("ecal")) && !step.Contains("cosmic") ){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "ecal")) && !stepContainsNU(step, "cosmic") ){
       //ecal rechit plots
       plotvar("EcalRecHitsSorted_ecalRecHit_EcalRecHitsEB_"+recoS+".obj.obj@.size()");
       plotvar("EcalRecHitsSorted_ecalRecHit_EcalRecHitsEB_"+recoS+".obj.obj.energy()");
@@ -1734,7 +1751,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
     }
 
 
-    if ((step.Contains("all") || step.Contains("dt")) && !step.Contains("cosmic") ){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "dt")) && !stepContainsNU(step, "cosmic") ){
       //dT segments
       tbr="DTChamberIdDTRecSegment4DsOwnedRangeMap_dt4DSegments__";
       plotvar(tbr+recoS+".obj.collection_.data_@.size()");
@@ -1770,7 +1787,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar(tbr+recoS+".obj.collection_.data_.localDirection().z()");
     }
 
-    if ((step.Contains("all") || step.Contains("csc")) && !step.Contains("cosmic") ){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "csc")) && !stepContainsNU(step, "cosmic") ){
       //csc rechits
       tbr="CSCDetIdCSCSegmentsOwnedRangeMap_cscSegments__";
       plotvar(tbr+recoS+".obj.collection_.data_@.size()");
@@ -1799,7 +1816,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar(tbr+recoS+".obj.collection_.data_.localPositionError().xy()");
     }
 
-    if ((step.Contains("all") || step.Contains("rpc")) && !step.Contains("cosmic") ){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "rpc")) && !stepContainsNU(step, "cosmic") ){
       tbr="RPCDetIdRPCRecHitsOwnedRangeMap_rpcRecHits__";
       plotvar(tbr+recoS+".obj@.size()");
       plotvar(tbr+recoS+".obj.collection_.data_.clusterSize()");
@@ -1812,7 +1829,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar(tbr+recoS+".obj.collection_.data_.localPositionError().xy()");
       
     }
-    if ((step.Contains("all") || step.Contains("gem")) && !step.Contains("cosmic") ){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "gem")) && !stepContainsNU(step, "cosmic") ){
       tbr="GEMDetIdGEMRecHitsOwnedRangeMap_gemRecHits__";
       plotvar(tbr+recoS+".obj@.size()");
       plotvar(tbr+recoS+".obj.collection_.data_.clusterSize()");
@@ -1840,7 +1857,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar(tbr+recoS+".obj.collection_.data_.localPositionError().yy()");
       plotvar(tbr+recoS+".obj.collection_.data_.localPositionError().xy()");
     }
-    if ((step.Contains("all") || step.Contains("me0")) && !step.Contains("cosmic") ){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "me0")) && !stepContainsNU(step, "cosmic") ){
       tbr="ME0DetIdME0RecHitsOwnedRangeMap_me0RecHits__";
       plotvar(tbr+recoS+".obj@.size()");
       plotvar(tbr+recoS+".obj.collection_.data_.tof()");
@@ -1866,7 +1883,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar(tbr+recoS+".obj.collection_.data_.localPositionError().yy()");
       plotvar(tbr+recoS+".obj.collection_.data_.localPositionError().xy()");
     }
-    if ((step.Contains("all") || step.Contains("sipixel")) && !step.Contains("cosmic") ){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "sipixel")) && !stepContainsNU(step, "cosmic") ){
       plotvar("SiPixelClusteredmNewDetSetVector_siPixelClusters__"+recoS+".obj.m_data@.size()");
       //plotvar("SiPixelClusteredmNewDetSetVector_siPixelClusters__"+recoS+".obj.m_data.barycenter()");
       plotvar("SiPixelClusteredmNewDetSetVector_siPixelClusters__"+recoS+".obj.m_data.charge()");
@@ -1891,7 +1908,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar(tbr+recoS+".obj.chi_");
       plotvar(tbr+recoS+".obj.chi(0)");
     }
-    if ((step.Contains("all") || step.Contains("sistrip")) && !step.Contains("cosmic") ){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "sistrip")) && !stepContainsNU(step, "cosmic") ){
       plotvar("SiStripClusteredmNewDetSetVector_siStripClusters__"+recoS+".obj.m_data@.size()");
       plotvar("SiStripClusteredmNewDetSetVector_siStripClusters__"+recoS+".obj.m_data.barycenter()");
       plotvar("log10(max(0.1,SiStripClusteredmNewDetSetVector_siStripClusters__"+recoS+".obj.m_data.amplitudes_@.size()))");
@@ -1914,7 +1931,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       }
     }
 
-    if ((step.Contains("all") || step.Contains("beamspot")) && !step.Contains("cosmic") ){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "beamspot")) && !stepContainsNU(step, "cosmic") ){
       /// beam spot plots
       plotvar("recoBeamSpot_offlineBeamSpot__"+recoS+".obj.type()");
       plotvar("recoBeamSpot_offlineBeamSpot__"+recoS+".obj.x0()");
@@ -1939,7 +1956,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       
     }
 
-    if ((step.Contains("all") || step.Contains("track")) && !step.Contains("cosmic") ){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "track")) && !stepContainsNU(step, "cosmic") ){
       /// general track plots
       allTracks("generalTracks__"+recoS+"");
       plotvar("floatedmValueMap_generalTracks_MVAVals_"+recoS+".obj.values_");
@@ -1955,17 +1972,17 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       }
 
     }
-    if (step.Contains("all")){
+    if (stepContainsNU(step, "all")){
       allTracks("regionalCosmicTracks__"+recoS+"");
       allTracks("cosmicDCTracks__"+recoS+"");
       allTracks("displacedGlobalMuons__"+recoS+"");
     }
-    if ((step.Contains("all") || step.Contains("pixeltrack")) && !step.Contains("cosmic") ){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "pixeltrack")) && !stepContainsNU(step, "cosmic") ){
       /// general track plots
       allTracks("pixelTracks__"+recoS+"");
     }
 
-    if (step.Contains("all")) {
+    if (stepContainsNU(step, "all")) {
       packedCand("packedPFCandidates_");
       packedCand("lostTracks_");
       packedCand("lostTracks_eleTracks");
@@ -1990,7 +2007,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar("min(30,"+tbr+recoS+".obj.pfNeutralSum())");
     }
     
-    if ((step.Contains("all") || step.Contains("vertex")) && !step.Contains("cosmic") ){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "vertex")) && !stepContainsNU(step, "cosmic") ){
       /// primary vertex plots
       vertexVars("recoVertexs_pixelVertices__");
       vertexVars("recoVertexs_offlinePrimaryVertices__");
@@ -2048,13 +2065,13 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar("log10(recoVertexCompositePtrCandidates_slimmedSecondaryVertices__"+recoS+".obj.vertexCovariance(3,3))/2");
     }
 
-    if ((step.Contains("all") || step.Contains("track")) && step.Contains("cosmic") ){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "track")) && stepContainsNU(step, "cosmic") ){
       ///cosmic tracks plots
       allTracks("ctfWithMaterialTracksP5__"+recoS+"");
     }
 
-    if ((step.Contains("all") || step.Contains("v0")) &&
-	!step.Contains("cosmic")){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "v0")) &&
+	!stepContainsNU(step, "cosmic")){
       // Kshort plots
       plotvar("recoVertexCompositeCandidates_generalV0Candidates_Kshort_"+recoS+".@obj.size()");
       V0("Kshort","pt");
@@ -2076,7 +2093,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
     }
 
 
-    if ((step.Contains("all") || step.Contains("dE")) && !step.Contains("cosmic")){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "dE")) && !stepContainsNU(step, "cosmic")){
       ///dedx plots 
       // median was replaced by dedxHarmonic2 in CMSSW_4_2
       //      plotvar("recoDeDxDataedmValueMap_dedxMedian__"+recoS+".obj.size()");
@@ -2108,7 +2125,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar("recoDeDxHitInfos_isolatedTracks__"+recoS+".obj.infos_.charge()");
     }
 
-    if ((step.Contains("all") || step.Contains("muon")) && !step.Contains("cosmic")){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "muon")) && !stepContainsNU(step, "cosmic")){
       ///STA muons plots
       plotvar("recoTracks_standAloneMuons_UpdatedAtVtx_"+recoS+".obj@.size()");
       staMuons("pt");
@@ -2194,7 +2211,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       muonVars("slimmedMuons_","patMuons_");
     }
 
-    if ((step.Contains("all") || step.Contains("tau")) && !step.Contains("cosmic") && !step.Contains("NoTaus")){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "tau")) && !stepContainsNU(step, "cosmic") && !stepContainsNU(step, "NoTaus")){
       // tau plots
       tauVars("hpsPFTauProducer_");
       // miniaod
@@ -2237,7 +2254,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       //      plotvar("recoRecoTauPiZeros_hpsPFTauProducer_pizeros_"+recoS+".obj.numberOfElectrons()");
   }
 
-  if (step.Contains("all") || step.Contains("conversion") || step.Contains("photon")){
+  if (stepContainsNU(step, "all") || stepContainsNU(step, "conversion") || stepContainsNU(step, "photon")){
       //converstion plots
       conversionVars("conversions_");
       conversionVars("allConversions_");
@@ -2257,7 +2274,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       */
     }
 
-    if (step.Contains("all") || step.Contains("photon")){
+    if (stepContainsNU(step, "all") || stepContainsNU(step, "photon")){
       //photon plots
       photonVars("photons_");
 
@@ -2371,7 +2388,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       superClusters("reducedEgamma_reducedOOTSuperClusters");
     }
 
-    if ((step.Contains("all") || step.Contains("electron")) && !step.Contains("cosmic")){
+    if ((stepContainsNU(step, "all") || stepContainsNU(step, "electron")) && !stepContainsNU(step, "cosmic")){
       ///electron plots
       electronVars("gsfElectrons_");
       electronVars("gedGsfElectrons_");
@@ -2402,7 +2419,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       gsfTrackVars("reducedEgamma_reducedGsfTracks");
     }
 
-    if (step.Contains("pfdebug")){
+    if (stepContainsNU(step, "pfdebug")){
       //for tests of PF hadron corrs
       TString var = "pt";
       TString pfName="recoPFCandidates_particleFlow__"+recoS+".obj";
@@ -2425,9 +2442,9 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
         sel2 = sel+"&&abs("+pfAl+".eta())>2.5";
         plotvar("log10(Sum$("+v+"*("+sel2+")))");
       }
-    }//step.Contains("pfdebug")
+    }//stepContainsNU(step, "pfdebug")
 
-    if (step.Contains("all") || step.Contains("pflow")){
+    if (stepContainsNU(step, "all") || stepContainsNU(step, "pflow")){
       ///particle flow objects
 
       allpf(-1, "particleFlow_");
@@ -2474,7 +2491,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
 
       plotvar("booledmValueMap_chargedHadronPFTrackIsolation__"+recoS+".obj.values_");
     }
-    if (step.Contains("all") || step.Contains("EI")){
+    if (stepContainsNU(step, "all") || stepContainsNU(step, "EI")){
       /* this existed only in 610pre
       plotvar("log10(recoPFJets_pfJets__"+recoS+".obj.pt())");
       plotvar("recoPFJets_pfJets__"+recoS+".obj.eta()");
@@ -2516,7 +2533,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar("recoPFTaus_pfTaus__"+recoS+".obj.isolationPFGammaCandsEtSum()");
       */
 
-      if (!step.Contains("NoTaus")){
+      if (!stepContainsNU(step, "NoTaus")){
 	plotvar("log10(recoPFTaus_pfTausEI__"+recoS+".obj.pt())");
 	plotvar("recoPFTaus_pfTausEI__"+recoS+".obj.eta()");
 	plotvar("recoPFTaus_pfTausEI__"+recoS+".obj.phi()");
@@ -2553,7 +2570,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar(""+recoS+".obj.()");
       */
     }
-    if (step.Contains("all") || step.Contains("met")){
+    if (stepContainsNU(step, "all") || stepContainsNU(step, "met")){
       ///MET plots
       metVars("tcMet_");
       metVars("tcMetWithPFclusters_");
@@ -2606,7 +2623,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       
     }
 
-    if (step.Contains("all") || step.Contains("calotower") || step.Contains("HEP17")){
+    if (stepContainsNU(step, "all") || stepContainsNU(step, "calotower") || stepContainsNU(step, "HEP17")){
       //calo towers plot
 
       plotvar("CaloTowersSorted_towerMaker__"+recoS+".obj.obj@.size()");
@@ -2617,7 +2634,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar("CaloTowersSorted_towerMaker__"+recoS+".obj.obj.eta()");
       plotvar("CaloTowersSorted_towerMaker__"+recoS+".obj.obj.phi()");
 
-      if (step.Contains("HEP17")){
+      if (stepContainsNU(step, "HEP17")){
 	plotvar("log10(CaloTowersSorted_towerMaker__"+recoS+".obj.obj.energy())", "CaloTowersSorted_towerMaker__"+recoS+".obj.obj.eta()>1.5&&CaloTowersSorted_towerMaker__"+recoS+".obj.obj.eta()<3&&CaloTowersSorted_towerMaker__"+recoS+".obj.obj.phi()<-0.435&&CaloTowersSorted_towerMaker__"+recoS+".obj.obj.phi()>-0.960");
 	plotvar("log10(CaloTowersSorted_towerMaker__"+recoS+".obj.obj.emEnergy())", "CaloTowersSorted_towerMaker__"+recoS+".obj.obj.eta()>1.5&&CaloTowersSorted_towerMaker__"+recoS+".obj.obj.eta()<3&&CaloTowersSorted_towerMaker__"+recoS+".obj.obj.phi()<-0.435&&CaloTowersSorted_towerMaker__"+recoS+".obj.obj.phi()>-0.960");
 	plotvar("log10(CaloTowersSorted_towerMaker__"+recoS+".obj.obj.hadEnergy())", "CaloTowersSorted_towerMaker__"+recoS+".obj.obj.eta()>1.5&&CaloTowersSorted_towerMaker__"+recoS+".obj.obj.eta()<3&&CaloTowersSorted_towerMaker__"+recoS+".obj.obj.phi()<-0.435&&CaloTowersSorted_towerMaker__"+recoS+".obj.obj.phi()>-0.960");
@@ -2645,7 +2662,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
 
     }
 
-    if (step.Contains("all") || step.Contains("jet")){
+    if (stepContainsNU(step, "all") || stepContainsNU(step, "jet")){
       
       ///jet plots
       jets("recoCaloJets","iterativeCone5CaloJets");
@@ -2734,7 +2751,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       //jets("patJets","slimmedJetsCMSTopTagCHSPacked_SubJets");      
     }
 
-    if (step.Contains("all") || step.Contains("jet")){
+    if (stepContainsNU(step, "all") || stepContainsNU(step, "jet")){
       jetTagVar("combinedSecondaryVertexMVABJetTags__");
       jetTagVar("combinedMVAV2BJetTags__");
       jetTagVar("combinedInclusiveSecondaryVertexV2BJetTags__");
@@ -2819,7 +2836,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       impactParameterTagInfoVars("recoTrackIPTagInfos_impactParameterTagInfosEI_ghostTracks_");
     }
       
-    if (step.Contains("all") || step.Contains("hfreco")){
+    if (stepContainsNU(step, "all") || stepContainsNU(step, "hfreco")){
       plotvar("recoRecoEcalCandidates_hfRecoEcalCandidate__"+recoS+".obj@.size()");
       plotvar("recoRecoEcalCandidates_hfRecoEcalCandidate__"+recoS+".obj.pt()");
       plotvar("recoRecoEcalCandidates_hfRecoEcalCandidate__"+recoS+".obj.eta()");

--- a/validate.C
+++ b/validate.C
@@ -837,6 +837,12 @@ void muonVars(TString cName = "muons_", TString tName = "recoMuons_"){
       plotvar(tName+cName+"_"+recoS+Form(".obj[].isolations_[%d]",i), "", true);
     }
 
+    muonVar("pfEcalEnergy", cName,tName);
+    muonVar("jetPtRatio", cName,tName);
+    muonVar("jetPtRel", cName,tName);
+    muonVar("mvaValue", cName,tName);
+    muonVar("softMvaValue", cName,tName);
+
     muonVar("simType", cName,tName);
     muonVar("simExtType", cName,tName);
     muonVar("simFlavour", cName,tName);


### PR DESCRIPTION
- map updates
    - 10811 added
    - fix 1325.7 wildcard to match to the latest update
    - make MC wildcards more inclusive to handle MC with external inputs ("INPUT" text may be added when that input is available)
- fwlite plots updates
    - step specifications now have an underscore enforced as a separator so that the map short name or other parts do not accidentally match the step specifications (in most cases we run "all_", but other options are present and are used occasionally)
    - add plots for pat::Muons for recently added variables
    - add plots for PF debugging (pfdebug_ step specification) for local tests, this currently covers specifics of PF hadron calibrations looking in eta ranges up to 1.5, 1.5 to 2.5 and 2.5 to 3
