### PR TITLE
fix/recover JPT jet plots; add HI remini packedCandidateMuonID plots

### DIFF
--- a/validate.C
+++ b/validate.C
@@ -3637,6 +3637,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       jets("recoTrackJets","ak5TrackJets");
       jets("recoTrackJets","ak4TrackJets");
       jets("recoJPTJets","JetPlusTrackZSPCorJetAntiKt5");
+      jets("recoJPTJets","JetPlusTrackZSPCorJetAntiKt4");
       jets("recoJPTJets", "TCTauJetPlusTrackZSPCorJetAntiKt5");
       jets("recoPFJets","ak5PFJets");
       jets("recoPFJets","ak5PFJetsCHS");

--- a/validate.C
+++ b/validate.C
@@ -2841,11 +2841,20 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       }
     }
 
-    if (stepContainsNU(step, "all")) {
+    if (stepContainsNU(step, "all") || stepContainsNU(step, "pat")) {
       packedCand("packedPFCandidates_");
       packedCand("lostTracks_");
       packedCand("lostTracks_eleTracks");
       packedCand("packedPFCandidatesDiscarded_");
+      packedCand("hiPixelTracks_");
+
+      for (const TString& inst : {"pfCandidatesTMOneStationTight", "pfCandidatesAllTrackerMuons", 
+                                 "lostTracksTMOneStationTight", "lostTracksAllTrackerMuons"} ) {
+        tbr="patPackedCandidatesRefs_packedCandidateMuonID_"+inst+"_"+recoS+".obj";
+        if (checkBranchOR(tbr, true)){
+          plotvar(tbr+"@.size()");
+        }
+      }
 
       tbr="patHcalDepthEnergyFractionsedmValueMap_packedPFCandidates_hcalDepthEnergyFractions_"+recoS+".obj";
       if (checkBranchOR(tbr, true)){

--- a/validateDQM.sh
+++ b/validateDQM.sh
@@ -25,7 +25,7 @@ fi
 cWD=`pwd`
 export pidList=""
 echo Start processing at `date`
-grep root ${inList} | grep -v "#" | while read -r dsN fNP procN comm; do 
+grep root ${inList} | grep -v "#" | while read -r dsN fNP procN procR comm; do 
     fN=`echo ${baseA}/${fNP} | cut -d" " -f1 | sed -e "s?^${baseA}/??g"`
     wfDirA=`echo ${baseA}/${fN} | sed -e 's?/[^/]*root??g'`
     dqmA=`find -L ${wfDirA} -maxdepth 1 -name DQM_V\*.root | tail -1 `
@@ -33,6 +33,7 @@ grep root ${inList} | grep -v "#" | while read -r dsN fNP procN comm; do
     wfDirB=`echo ${baseB}/${fN} | sed -e 's?/[^/]*root??g'`
     dqmB=`find -L ${wfDirB} -maxdepth 1 -name DQM_V\*.root | tail -1 `
     [ "x${dqmB}" == "x" ] && echo "Missing DQM file in ${wfDirB}" && continue
+    [ "x${procN}" == "xNANO" ] && echo "Skip map entry with .root process NANO; NOT SUPPORTED YET" && continue
 
     extN=dqm_${diffN}_${dsN}
     mkdir -p ${extN}


### PR DESCRIPTION
- fix/recover JPT jet plots, which were inadvertently abandoned after AK5 -> AK4 migration
- add HI remini packedCandidateMuonID plots
- fix validateDQM.sh to not redo reco DQM diffs on workflows which have nano root comparisons 