### PR TITLE
plots for slimmed hcal hits, slimmed/reduced muon clusters/extras; and more

### DIFF
--- a/printFWLite.C
+++ b/printFWLite.C
@@ -48,6 +48,31 @@ void print_patJets_btags(const std::string& fName,
   }//event loop
 }
 
+void print_patJets_userFloats(const std::string& fName, const std::string& cName,
+                              int nEvts = 1){
+  TFile* f = new TFile(fName.c_str());
+  cout<<" loaded file "<<std::endl;
+
+  fwlite::Event e(f);
+  int eCount = 0;
+  for (e.toBegin(); ! e.atEnd() && (eCount < nEvts || nEvts < 0); ++e, ++eCount){
+    cout<<" loaded event "<<e.id().event()<<endl;
+    
+    fwlite::Handle<pat::JetCollection> jh;
+    jh.getByLabel(e, cName.c_str());
+    
+    int iJ = 0;
+    for (auto const& j : jh.ref()){
+      int iF = 0;
+      for (auto const& fn : j.userFloatNames()) {
+        cout<<"jet "<<iJ<<" "<<j.pt()<<" userFloat "<<iF<<" "<<fn<<" "<<j.userFloat(fn)<<endl;
+        ++iF;
+      }
+      ++iJ;
+    }
+  }//event loop
+}
+
 
 void compare_patJets_btags(const std::string& fNameRef, const std::string& fNameNew, const std::string jetName = "slimmedJetsAK8",
                            int nEvts = 1, bool allowNew = true, bool allowValueDiffs = true, float minRel = -1,

--- a/validate.C
+++ b/validate.C
@@ -2121,6 +2121,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
         plotvar("log2(max("+tbr+".obj.flags(),0.5))", tbr+".obj.detid().subdetId()==1");
         plotvar(tbr+".obj.time()", tbr+".obj.detid().subdetId()==1");
         plotvar("log10("+tbr+".obj.chi2())", tbr+".obj.detid().subdetId()==1");
+        plotvar("log10("+tbr+".obj.chi2())", tbr+".obj.energy()>0.001&&"+tbr+".obj.detid().subdetId()==1");
 
         plotvar(tbr+".obj.energy()", tbr+".obj.detid().subdetId()!=1");
         plotvar("log10("+tbr+".obj.energy())", tbr+".obj.detid().subdetId()!=1");
@@ -2132,6 +2133,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
         plotvar("log2(max("+tbr+".obj.flags(),0.5))", tbr+".obj.detid().subdetId()!=1");
         plotvar(tbr+".obj.time()", tbr+".obj.detid().subdetId()!=1");
         plotvar("log10("+tbr+".obj.chi2())", tbr+".obj.detid().subdetId()!=1");
+        plotvar("log10("+tbr+".obj.chi2())", tbr+".obj.energy()>0.001&&"+tbr+".obj.detid().subdetId()!=1");
 
         if (stepContainsNU(step, "HEP17")){
           plotvar(tbr+".obj.energy()", tbr+".obj.detid().subdetId()!=1&&"+tbr+".obj.id().iphi()>=63&&"+tbr+".obj.id().iphi()<=66");

--- a/validate.C
+++ b/validate.C
@@ -839,6 +839,8 @@ void electronVars(TString cName = "gsfElectrons_", TString tName = "recoGsfElect
     electron("miniPFIsolation().photonIso", cName,tName);
     electron("miniPFIsolation().puChargedHadronIso", cName,tName);
 
+    electron("dB(pat::Electron::PV2D)", cName,tName, true);
+    electron("dB(pat::Electron::BS2D)", cName,tName, true);
     electron("dB(pat::Electron::PV3D)", cName,tName, true);
     electron("dB(pat::Electron::PVDZ)", cName,tName, true);
 
@@ -1006,6 +1008,8 @@ void muonVars(TString cName = "muons_", TString tName = "recoMuons_"){
     muonVar("miniPFIsolation().photonIso", cName,tName);
     muonVar("miniPFIsolation().puChargedHadronIso", cName,tName);
 
+    muonVar("dB(pat::Muon::PV2D)", cName,tName, true);
+    muonVar("dB(pat::Muon::BS2D)", cName,tName, true);
     muonVar("dB(pat::Muon::PV3D)", cName,tName, true);
     muonVar("dB(pat::Muon::PVDZ)", cName,tName, true);
 

--- a/validate.C
+++ b/validate.C
@@ -152,6 +152,7 @@ PlotStats plotvar(TString v,TString cut="", bool tryCatch = false){
   gStyle->SetTitleW(1);
   gStyle->SetTitleH(0.06);
   TGaxis::SetExponentOffset(-0.052,-0.060,"x");
+  TGaxis::SetExponentOffset(-0.052,0.010,"y");
 
   res.ref_entries = -1;
   res.new_entries = -1;
@@ -261,10 +262,10 @@ PlotStats plotvar(TString v,TString cut="", bool tryCatch = false){
     res.ksProb = refplot->KolmogorovTest(plot);
 
     TString outtext;
-    outtext.Form("Ref: %i, New: %i, De: %g, Diff: %g, 1-KS: %6.4g",res.ref_entries,res.new_entries,
+    outtext.Form("Ref: %i, New: %i, De: %6.4g, Diff: %g, 1-KS: %6.4g",res.ref_entries,res.new_entries,
                  res.ref_entries>0? (res.new_entries-res.ref_entries)/double(res.ref_entries):0, res.countDiff,1-res.ksProb);
 
-    TPaveText * pt = new TPaveText(0.01,0.89,0.71,0.93,"NDC");
+    TPaveText * pt = new TPaveText(0.05,0.89,0.71,0.93,"NDC");
     pt->AddText(outtext);
     pt->SetBorderSize(0);
     pt->SetFillStyle(0);

--- a/validate.C
+++ b/validate.C
@@ -151,7 +151,7 @@ PlotStats plotvar(TString v,TString cut="", bool tryCatch = false){
   gStyle->SetTitleY(1);
   gStyle->SetTitleW(1);
   gStyle->SetTitleH(0.06);
-  TGaxis::SetExponentOffset(-0.042,-0.035,"x");
+  TGaxis::SetExponentOffset(-0.052,-0.060,"x");
 
   res.ref_entries = -1;
   res.new_entries = -1;

--- a/validate.C
+++ b/validate.C
@@ -1343,6 +1343,41 @@ void mtdHits(TString cName){
   plotvar("log2(max("+bObj+".obj.flagBits_,0.5))");
 }
 
+void siStripClusters(TString cName){
+  TString bObj="SiStripClusteredmNewDetSetVector_"+cName+"_"+recoS+".obj";
+  if (! checkBranchOR(bObj, true)) return;
+
+  plotvar(bObj+".m_data@.size()");
+  plotvar(bObj+".m_data.barycenter()");
+  plotvar("log10(max(0.1,"+bObj+".m_data.amplitudes_@.size()))");
+  plotvar("min(50,"+bObj+".m_data.amplitudes_@.size())");
+}
+
+void siPixelClusters(TString cName){
+  TString bObj="SiPixelClusteredmNewDetSetVector_"+cName+"_"+recoS+".obj";
+  if (! checkBranchOR(bObj, true)) return;
+
+  plotvar(bObj+".m_data@.size()");
+  plotvar(bObj+".m_data.charge()");
+  plotvar("log10(max(0.1,"+bObj+".m_data.size()))");
+  plotvar("min(50,"+bObj+".m_data.size())");
+}
+
+void trackExtras(TString cName){
+  TString bObj="recoTrackExtras_"+cName+"_"+recoS+".obj";
+  if (! checkBranchOR(bObj, true)) return;
+
+  plotvar(bObj+"@.size()");
+  plotvar(bObj+".recHitsSize()");
+  plotvar(bObj+".innerOk()+2*"+bObj+".outerOk()+");
+  plotvar(bObj+".innerPosition().z()", bObj+".innerOk()");
+  plotvar(bObj+".innerPosition().rho()", bObj+".innerOk()");
+  plotvar("log10("+bObj+".innerMomentum().pt())", bObj+".innerOk()");
+  plotvar(bObj+".outerPosition().z()", bObj+".outerOk()");
+  plotvar(bObj+".outerPosition().rho()", bObj+".outerOk()");
+  plotvar("log10("+bObj+".outerMomentum().pt())", bObj+".outerOk()");
+}
+
 void forwardProtons(TString cName ){
   TString bObj = "recoForwardProtons_"+cName+"_"+recoS+".obj";
   if (! checkBranchOR(bObj, true)) return;
@@ -2649,14 +2684,9 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       }
     }
     if ((stepContainsNU(step, "all") || stepContainsNU(step, "sipixel")) && !stepContainsNU(step, "cosmic") ){
-      tbr="SiPixelClusteredmNewDetSetVector_siPixelClusters__"+recoS+".obj";
-      if (checkBranchOR(tbr, true)){
-        plotvar(tbr+".m_data@.size()");
-        //plotvar(tbr+".m_data.barycenter()");
-        plotvar(tbr+".m_data.charge()");
-        plotvar("log10(max(0.1,"+tbr+".m_data.size()))");
-        plotvar("min(50,"+tbr+".m_data.size())");
-      }
+      siPixelClusters("siPixelClusters_");
+      siPixelClusters("muonReducedTrackExtras_");
+      siPixelClusters("slimmedMuonTrackExtras_");
 
       tbr="Phase2TrackerCluster1DedmNewDetSetVector_siPhase2Clusters__"+recoS+".obj";
       if (checkBranchOR(tbr, true)){
@@ -2685,14 +2715,9 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       }
     }
     if ((stepContainsNU(step, "all") || stepContainsNU(step, "sistrip")) && !stepContainsNU(step, "cosmic") ){
-      tbr="SiStripClusteredmNewDetSetVector_siStripClusters__"+recoS+".obj";
-      if (checkBranchOR(tbr, true)){
-        plotvar(tbr+".m_data@.size()");
-        plotvar(tbr+".m_data.barycenter()");
-        plotvar("log10(max(0.1,"+tbr+".m_data.amplitudes_@.size()))");
-        plotvar("min(50,"+tbr+".m_data.amplitudes_@.size())");
-        //plotvar(tbr+".m_data.amplitudes()[0]");
-      }
+      siStripClusters("siStripClusters_");
+      siStripClusters("muonReducedTrackExtras_");
+      siStripClusters("slimmedMuonTrackExtras_");
 
       tbr="ClusterSummary_clusterSummaryProducer__"+recoS+".obj";
       if (checkBranchOR(tbr, true)){
@@ -2757,7 +2782,6 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
 	//	allTracks("thWithMaterialTracks__"+recoS);
 	//	allTracks("secWithMaterialTracks__"+recoS);
       }
-
     }
     if (stepContainsNU(step, "all")){
       allTracks("regionalCosmicTracks__"+recoS);
@@ -3011,6 +3035,9 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       allTracks("tevMuons_dyt_"+recoS);
       allTracks("tevMuons_picky_"+recoS);
       allTracks("standAloneSETMuons_UpdatedAtVtx_"+recoS);
+
+      trackExtras("muonReducedTrackExtras_");
+      trackExtras("slimmedMuonTrackExtras_");
 
       ///tracker muons
       tbr="recoMuons_muons__"+recoS+".obj";

--- a/validate.C
+++ b/validate.C
@@ -1308,6 +1308,25 @@ void V0(TString res, TString var){
   plotvar(v);
 }
 
+void caloHitsGeneric(TString tName, TString cName){
+  TString bObj=tName+"_"+cName+"_"+recoS+".obj";
+  if (! checkBranchOR(bObj, true)) return;
+
+  plotvar(bObj+".obj@.size()");
+  plotvar(bObj+".obj.energy()");
+  plotvar("log10("+bObj+".obj.energy())");
+  plotvar("log10("+bObj+".obj.energy())", bObj+".obj.energy()>0.001");
+  if (tName == "HBHERecHitsSorted"){
+    plotvar(bObj+".obj.eraw()");
+    plotvar("log10("+bObj+".obj.eraw())");
+    plotvar(bObj+".obj.eaux()");
+    plotvar("log10("+bObj+".obj.eaux())");
+    plotvar("log10("+bObj+".obj.chi2())");
+  }
+  plotvar("log2(max("+bObj+".obj.flags(),0.5))");
+  plotvar(bObj+".obj.time()");
+}
+
 void mtdHits(TString cName){
   TString tbr="FTLRecHitsSorted_"+cName+"_";
   TString bObj = tbr+recoS+".obj";
@@ -2094,19 +2113,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
     }
     if ((stepContainsNU(step, "all") || stepContainsNU(step, "hcal")) && !stepContainsNU(step, "cosmic") ){
       //hcal rechit plots
-      tbr="HBHERecHitsSorted_hbheprereco__"+recoS+".obj";
-      if (checkBranchOR(tbr, true)){
-        plotvar(tbr+".obj@.size()");
-        plotvar(tbr+".obj.energy()");
-        plotvar("log10("+tbr+".obj.energy())");
-        plotvar(tbr+".obj.eraw()");
-        plotvar("log10("+tbr+".obj.eraw())");
-        plotvar(tbr+".obj.eaux()");
-        plotvar("log10("+tbr+".obj.eaux())");
-        plotvar("log2(max("+tbr+".obj.flags(),0.5))");
-        plotvar(tbr+".obj.time()");
-        plotvar("log10("+tbr+".obj.chi2())");
-      }
+      caloHitsGeneric("HBHERecHitsSorted", "hbheprereco_");
 
       tbr="HBHERecHitsSorted_hbhereco__"+recoS+".obj";
       if (checkBranchOR(tbr, true)){
@@ -2161,32 +2168,9 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
         }
       }//check HBHERecHitsSorted_hbhereco__ is available
 
-      tbr="HBHERecHitsSorted_reducedHcalRecHits_hbhereco_"+recoS+".obj";
-      if (checkBranchOR(tbr, true)){
-        plotvar(tbr+".obj@.size()");
-        plotvar(tbr+".obj.energy()");
-        plotvar("log10("+tbr+".obj.energy())");
-        plotvar(tbr+".obj.eraw()");
-        plotvar("log10("+tbr+".obj.eraw())");
-        plotvar(tbr+".obj.eaux()");
-        plotvar("log10("+tbr+".obj.eaux())");
-        plotvar("log2(max("+tbr+".obj.flags(),0.5))");
-        plotvar(tbr+".obj.time()");
-        plotvar("log10("+tbr+".obj.chi2())");
-      }
-      tbr="HBHERecHitsSorted_reducedEgamma_reducedHBHEHits_"+recoS+".obj";
-      if (checkBranchOR(tbr, true)){
-        plotvar(tbr+".obj@.size()");
-        plotvar(tbr+".obj.energy()");
-        plotvar("log10("+tbr+".obj.energy())");
-        plotvar(tbr+".obj.eraw()");
-        plotvar("log10("+tbr+".obj.eraw())");
-        plotvar(tbr+".obj.eaux()");
-        plotvar("log10("+tbr+".obj.eaux())");
-        plotvar("log2(max("+tbr+".obj.flags(),0.5))");
-        plotvar(tbr+".obj.time()");
-        plotvar("log10("+tbr+".obj.chi2())");
-      }
+      caloHitsGeneric("HBHERecHitsSorted", "reducedHcalRecHits_hbhereco");
+      caloHitsGeneric("HBHERecHitsSorted", "reducedEgamma_reducedHBHEHits");
+      caloHitsGeneric("HBHERecHitsSorted", "slimmedHcalRecHits_reducedHcalRecHits");
 
       tbr="HFPreRecHitsSorted_hfprereco__"+recoS+".obj";
       if (checkBranchOR(tbr, true)){
@@ -2198,63 +2182,16 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
         plotvar(tbr+".obj.hasInfo_[1]");
       }
 
-      tbr="HFRecHitsSorted_hfreco__"+recoS+".obj";
-      if (checkBranchOR(tbr, true)){
-        plotvar(tbr+".obj@.size()");
-        plotvar(tbr+".obj.energy()");
-        plotvar("log10("+tbr+".obj.energy())");
-        plotvar("log10("+tbr+".obj.energy())", tbr+".obj.energy()>0.001");
-        plotvar("log2(max("+tbr+".obj.flags(),0.5))");
-        plotvar(tbr+".obj.time()");
-      }
+      caloHitsGeneric("HFRecHitsSorted", "hfreco_");
+      caloHitsGeneric("HFRecHitsSorted", "reducedHcalRecHits_hfreco");
+      caloHitsGeneric("HFRecHitsSorted", "slimmedHcalRecHits_reducedHcalRecHits");
 
-      tbr="HFRecHitsSorted_reducedHcalRecHits_hfreco_"+recoS+".obj";
-      if (checkBranchOR(tbr, true)){
-        plotvar(tbr+".obj@.size()");
-        plotvar(tbr+".obj.energy()");
-        plotvar("log10("+tbr+".obj.energy())");
-        plotvar("log2(max("+tbr+".obj.flags(),0.5))");
-        plotvar(tbr+".obj.time()");
-      }
+      caloHitsGeneric("HORecHitsSorted", "horeco_");
+      caloHitsGeneric("HORecHitsSorted", "reducedHcalRecHits_horeco");
+      caloHitsGeneric("HORecHitsSorted", "slimmedHcalRecHits_reducedHcalRecHits");
 
-      tbr="HORecHitsSorted_horeco__"+recoS+".obj";
-      if (checkBranchOR(tbr, true)){
-        plotvar(tbr+".obj@.size()");
-        plotvar(tbr+".obj.energy()");
-        plotvar("log10("+tbr+".obj.energy())");
-        plotvar("log10("+tbr+".obj.energy())", tbr+".obj.energy()>0.001");
-        plotvar("log2(max("+tbr+".obj.flags(),0.5))");
-        plotvar(tbr+".obj.time()");
-      }
-
-      tbr="HORecHitsSorted_reducedHcalRecHits_horeco_"+recoS+".obj";
-      if (checkBranchOR(tbr, true)){
-        plotvar(tbr+".obj@.size()");
-        plotvar(tbr+".obj.energy()");
-        plotvar("log10("+tbr+".obj.energy())");
-        plotvar("log2(max("+tbr+".obj.flags(),0.5))");
-        plotvar(tbr+".obj.time()");
-      }
-
-      tbr="CastorRecHitsSorted_castorreco__"+recoS+".obj";
-      if (checkBranchOR(tbr, true)){
-        plotvar(tbr+".obj@.size()");
-        plotvar(tbr+".obj.energy()");
-        plotvar("log10("+tbr+".obj.energy())");
-        plotvar("log10("+tbr+".obj.energy())", tbr+".obj.energy()>0.001");
-        plotvar("log2(max("+tbr+".obj.flags(),0.5))");
-        plotvar(tbr+".obj.time()");
-      }
-
-      tbr="ZDCRecHitsSorted_zdcreco__"+recoS+".obj";
-      if (checkBranchOR(tbr, true)){
-        plotvar(tbr+".obj@.size()");
-        plotvar(tbr+".obj.energy()");
-        plotvar("log10("+tbr+".obj.energy())");
-        plotvar("log10("+tbr+".obj.energy())", tbr+".obj.energy()>0.001");
-        plotvar("log2(max("+tbr+".obj.flags(),0.5))");
-        plotvar(tbr+".obj.time()");
-      }
+      caloHitsGeneric("CastorRecHitsSorted", "castorreco_");
+      caloHitsGeneric("ZDCRecHitsSorted", "zdcreco_");
 
       tbr="HcalNoiseSummary_hcalnoise__"+recoS+".obj";
       if (checkBranchOR(tbr, true)){


### PR DESCRIPTION
- changes in validate.C
    - for slimmed/reduced muon clusters/extras from PR 31217: add some basic plots or `reco::TrackExtra` and the associated pixel/strip clusters
        - comes with some refactoring of existing plotting methods for the tracker clusters
    - for slimmedHcalRecHits from PR 31375 : basic plots for HBHE/HO/HF hits are added
        - comes with some refactoring of existing plotting methods for the calo rec hits
    - add a plot for hbhe rechits chi2 after some minimal energy cut
    - add pat Electron and Muon BS2D and PV2D plots
    - adjust the stats text and the exponent label offset for x and y axis plots to avoid/minimize overlapping or invisible text
        - resolves #194
- update FWlite compiled script : `print_patJets_userFloats` to print userFloat details